### PR TITLE
Set English as default locale and preserve Arabic RTL support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+DATABASE_URL="postgresql://postgres:postgres@localhost:5432/aibizos"
+NEXTAUTH_URL="http://localhost:3000"
+NEXTAUTH_SECRET="change-me"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,50 @@
+# AiBizos – AI Business OS Core
+
+Next.js 14 + TypeScript + Tailwind + Prisma + NextAuth + next-intl core for multi-tenant AI-first operations.
+
+## Setup
+1. `cp .env.example .env`
+2. Set `DATABASE_URL` and `NEXTAUTH_SECRET`
+3. `npm install`
+4. `npx prisma migrate dev`
+5. `npm run prisma:seed`
+6. `npm run dev`
+
+## Brand assets
+Copy the provided PNG assets into `assets/brand/` with exact filenames. Copy `assets/brand/favicon.png` to `public/favicon.png`.
+
+## Add a module app
+1. Create `/modules/<appId>/manifest.ts`.
+2. Add app metadata (`id, routes, permissions, events, aiActions`).
+3. Seed into `core_apps_registry`.
+4. App appears in marketplace and tenant install table `core_tenant_apps`.
+
+## Permissions
+- Global catalog in `core_permissions`.
+- Tenant roles in `core_roles` + `core_role_permissions`.
+- Membership role assignment in `core_membership_roles`.
+- Enforce with `requireTenantContext` + `requirePermission`.
+
+## Events + audit
+- Publish events with `publishEvent(tenantId, type, payload, actor)` => persists `core_events`.
+- Write audit logs with `writeAudit(...)` => persists `core_audit_logs`.
+- Every human/AI action should call audit writer.
+
+## AI actions
+Flow:
+1. Prompt
+2. Plan (`parsePromptToActions` deterministic fallback)
+3. Dry-run preview (stored in AI run plan/toolCalls)
+4. Confirm
+5. Execute (`executeAiRun`) with audit entry
+
+Demo actions:
+- tenant setting draft
+- invite draft
+- install app draft
+- invoice draft (never finalized)
+
+## Security notes
+- Tenant-owned tables include `tenantId` with composite indexes.
+- Invitation token hashes only (`sha256`) in storage.
+- Invitations support pending/accepted/revoked/expired with expiry index.

--- a/app/[locale]/admin/audit/page.tsx
+++ b/app/[locale]/admin/audit/page.tsx
@@ -1,0 +1,6 @@
+import { prisma } from '@/lib/prisma';
+
+export default async function AuditPage() {
+  const logs = await prisma.coreAuditLog.findMany({ orderBy: { createdAt: 'desc' }, take: 50 });
+  return <div className="space-y-2">{logs.map((l) => <div key={l.id}>{l.action} · {l.entity}</div>)}</div>;
+}

--- a/app/[locale]/admin/events/page.tsx
+++ b/app/[locale]/admin/events/page.tsx
@@ -1,0 +1,6 @@
+import { prisma } from '@/lib/prisma';
+
+export default async function EventsPage() {
+  const events = await prisma.coreEvent.findMany({ orderBy: { createdAt: 'desc' }, take: 50 });
+  return <div className="space-y-2">{events.map((e) => <div key={e.id}>{e.type}</div>)}</div>;
+}

--- a/app/[locale]/admin/roles/page.tsx
+++ b/app/[locale]/admin/roles/page.tsx
@@ -1,0 +1,6 @@
+import { prisma } from '@/lib/prisma';
+
+export default async function RolesPage() {
+  const roles = await prisma.coreRole.findMany({ include: { permissions: { include: { permission: true } } } });
+  return <div className="space-y-2">{roles.map((r) => <div key={r.id}>{r.name}: {r.permissions.map((p) => p.permission.key).join(', ')}</div>)}</div>;
+}

--- a/app/[locale]/admin/users/page.tsx
+++ b/app/[locale]/admin/users/page.tsx
@@ -1,0 +1,6 @@
+import { prisma } from '@/lib/prisma';
+
+export default async function UsersAdminPage() {
+  const memberships = await prisma.coreMembership.findMany({ include: { user: true, tenant: true } });
+  return <div className="space-y-2">{memberships.map((m) => <div key={m.id}>{m.user.email} - {m.tenant.name}</div>)}</div>;
+}

--- a/app/[locale]/ai/runs/page.tsx
+++ b/app/[locale]/ai/runs/page.tsx
@@ -1,0 +1,6 @@
+import { prisma } from '@/lib/prisma';
+
+export default async function AiRunsPage() {
+  const runs = await prisma.coreAiRun.findMany({ orderBy: { createdAt: 'desc' }, take: 50 });
+  return <div className="space-y-2">{runs.map((r) => <div key={r.id}>{r.prompt} · {r.status}</div>)}</div>;
+}

--- a/app/[locale]/apps/page.tsx
+++ b/app/[locale]/apps/page.tsx
@@ -1,0 +1,6 @@
+import { prisma } from '@/lib/prisma';
+
+export default async function AppsPage() {
+  const apps = await prisma.coreAppRegistry.findMany();
+  return <div className="space-y-4">{apps.map((app) => <div key={app.id} className="rounded border border-slate-700 p-3">{app.id}</div>)}</div>;
+}

--- a/app/[locale]/auth/login/page.tsx
+++ b/app/[locale]/auth/login/page.tsx
@@ -1,0 +1,3 @@
+export default function LoginPage() {
+  return <div className="max-w-md rounded-md border border-slate-700 p-6">Use NextAuth credentials at /api/auth/signin</div>;
+}

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -1,0 +1,16 @@
+import { NextIntlClientProvider } from 'next-intl';
+import { getMessages } from 'next-intl/server';
+import { AppShell } from '@/components/shell';
+
+export default async function LocaleLayout({ children, params }: { children: React.ReactNode; params: { locale: string } }) {
+  const messages = await getMessages();
+  const dir = params.locale === 'ar' ? 'rtl' : 'ltr';
+
+  return (
+    <NextIntlClientProvider messages={messages} locale={params.locale}>
+      <div dir={dir}>
+        <AppShell locale={params.locale}>{children}</AppShell>
+      </div>
+    </NextIntlClientProvider>
+  );
+}

--- a/app/[locale]/onboarding/page.tsx
+++ b/app/[locale]/onboarding/page.tsx
@@ -1,0 +1,3 @@
+export default function OnboardingPage() {
+  return <div className="space-y-4"><h1 className="text-xl">Onboarding</h1><p>Create company, join via invite token, or personal sandbox.</p></div>;
+}

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -1,0 +1,19 @@
+import { prisma } from '@/lib/prisma';
+
+export default async function HomePage() {
+  const tenants = await prisma.coreTenant.count();
+  const users = await prisma.coreUser.count();
+  const invites = await prisma.coreInvitation.count({ where: { status: 'pending' } });
+
+  return (
+    <div className="grid gap-4 md:grid-cols-3">
+      <Card label="Tenants" value={tenants} />
+      <Card label="Users" value={users} />
+      <Card label="Pending Invites" value={invites} />
+    </div>
+  );
+}
+
+function Card({ label, value }: { label: string; value: number }) {
+  return <div className="rounded-lg border border-slate-700 bg-slate-900 p-4"><p className="text-muted">{label}</p><p className="text-2xl">{value}</p></div>;
+}

--- a/app/[locale]/settings/page.tsx
+++ b/app/[locale]/settings/page.tsx
@@ -1,0 +1,3 @@
+export default function SettingsPage() {
+  return <div>Tenant and module settings (draft-first updates).</div>;
+}

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,5 @@
+import NextAuth from 'next-auth';
+import { authOptions } from '@/lib/auth';
+
+const handler = NextAuth(authOptions);
+export { handler as GET, handler as POST };

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,6 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root { color-scheme: dark; }
+body { @apply bg-background text-foreground; }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,10 @@
+import './globals.css';
+import type { ReactNode } from 'react';
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en" dir="ltr" className="dark">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/assets/brand/README.md
+++ b/assets/brand/README.md
@@ -1,0 +1,7 @@
+Place provided brand PNG files here with exact names:
+- logo-primary.png
+- logo-dark.png
+- logo-light.png
+- icon-app.png
+- favicon.png
+- os-badge.png

--- a/components/brand-asset.tsx
+++ b/components/brand-asset.tsx
@@ -1,0 +1,7 @@
+import Image from 'next/image';
+
+type BrandVariant = 'logo-primary' | 'logo-dark' | 'logo-light' | 'icon-app' | 'favicon' | 'os-badge';
+
+export function BrandAsset({ variant, alt, className }: { variant: BrandVariant; alt: string; className?: string }) {
+  return <Image src={`/assets/brand/${variant}.png`} alt={alt} width={160} height={48} className={className} />;
+}

--- a/components/shell.tsx
+++ b/components/shell.tsx
@@ -1,0 +1,32 @@
+import Link from 'next/link';
+import { ReactNode } from 'react';
+import { BrandAsset } from './brand-asset';
+
+export function AppShell({ children, locale }: { children: ReactNode; locale: string }) {
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <div className="grid grid-cols-[240px_1fr]">
+        <aside className="border-e border-slate-700 p-4">
+          <BrandAsset variant="logo-light" alt="AiBizos" className="mb-8 h-auto w-36" />
+          <nav className="space-y-2 text-sm">
+            <Link href={`/${locale}`}>Dashboard</Link><br />
+            <Link href={`/${locale}/apps`}>Apps</Link><br />
+            <Link href={`/${locale}/settings`}>Settings</Link><br />
+            <Link href={`/${locale}/admin/users`}>Users</Link><br />
+            <Link href={`/${locale}/admin/roles`}>Roles</Link><br />
+            <Link href={`/${locale}/admin/audit`}>Audit</Link><br />
+            <Link href={`/${locale}/admin/events`}>Events</Link><br />
+            <Link href={`/${locale}/ai/runs`}>AI Runs</Link>
+          </nav>
+        </aside>
+        <main>
+          <header className="flex items-center justify-between border-b border-slate-700 p-4">
+            <input className="w-full max-w-2xl rounded-md bg-slate-800 px-3 py-2" placeholder="Ask AI: plan then preview then confirm" />
+            <div className="ms-4 text-xs text-muted">Company | Locale | Profile</div>
+          </header>
+          <div className="p-6">{children}</div>
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/i18n.ts
+++ b/i18n.ts
@@ -1,0 +1,6 @@
+import { getRequestConfig } from 'next-intl/server';
+
+export default getRequestConfig(async ({ locale }) => ({
+  locale,
+  messages: (await import(`./messages/${locale}.json`)).default
+}));

--- a/lib/ai.ts
+++ b/lib/ai.ts
@@ -1,0 +1,38 @@
+import { prisma } from '@/lib/prisma';
+import { writeAudit } from '@/lib/audit';
+
+type DraftAction =
+  | { type: 'setting_draft'; key: string; value: string }
+  | { type: 'invite_draft'; email: string }
+  | { type: 'install_app_draft'; appId: string }
+  | { type: 'invoice_draft'; customer: string; amount: number };
+
+export function parsePromptToActions(prompt: string): DraftAction[] {
+  const text = prompt.toLowerCase();
+  if (text.includes('invite') && text.includes('@')) {
+    const email = prompt.match(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i)?.[0] ?? 'teammate@example.com';
+    return [{ type: 'invite_draft', email }];
+  }
+  if (text.includes('install') && text.includes('crm')) return [{ type: 'install_app_draft', appId: 'crm' }];
+  if (text.includes('invoice')) return [{ type: 'invoice_draft', customer: 'Demo Customer', amount: 1000 }];
+  return [{ type: 'setting_draft', key: 'general.note', value: prompt }];
+}
+
+export async function planAiRun(tenantId: string, actorUserId: string, prompt: string) {
+  const actions = parsePromptToActions(prompt);
+  return prisma.coreAiRun.create({
+    data: { tenantId, actorUserId, prompt, plan: actions as unknown as object, status: 'preview_ready', toolCalls: [] }
+  });
+}
+
+export async function executeAiRun(runId: string) {
+  const run = await prisma.coreAiRun.findUniqueOrThrow({ where: { id: runId } });
+  await prisma.coreAiRun.update({ where: { id: runId }, data: { status: 'executed', toolCalls: run.plan } });
+  await writeAudit({
+    tenantId: run.tenantId,
+    actorUserId: run.actorUserId,
+    action: 'ai.execute',
+    entity: 'core_ai_runs',
+    after: { runId, plan: run.plan }
+  });
+}

--- a/lib/apps.ts
+++ b/lib/apps.ts
@@ -1,0 +1,40 @@
+export type AppManifest = {
+  id: string;
+  name: string;
+  description: string;
+  icon: string;
+  routes: string[];
+  requiredPermissions: string[];
+  settingsSections?: string[];
+  eventsPublished?: string[];
+  eventsSubscribed?: string[];
+  aiActions?: string[];
+  tags?: string[];
+};
+
+export const builtinApps: AppManifest[] = [
+  {
+    id: 'crm',
+    name: 'CRM',
+    description: 'Customer relationship workflows.',
+    icon: 'Users',
+    routes: ['/modules/crm'],
+    requiredPermissions: ['apps.view.crm'],
+    settingsSections: ['crm.pipeline'],
+    eventsPublished: ['crm.contact.created'],
+    aiActions: ['create-contact-draft'],
+    tags: ['sales']
+  },
+  {
+    id: 'invoicing',
+    name: 'Invoicing',
+    description: 'Draft-first invoicing module.',
+    icon: 'Receipt',
+    routes: ['/modules/invoicing'],
+    requiredPermissions: ['apps.view.invoicing'],
+    settingsSections: ['invoice.defaults'],
+    eventsPublished: ['invoice.draft.created'],
+    aiActions: ['create-invoice-draft'],
+    tags: ['finance']
+  }
+];

--- a/lib/audit.ts
+++ b/lib/audit.ts
@@ -1,0 +1,13 @@
+import { prisma } from '@/lib/prisma';
+
+export async function writeAudit(params: {
+  tenantId: string;
+  actorUserId?: string;
+  action: string;
+  entity: string;
+  before?: unknown;
+  after?: unknown;
+  meta?: unknown;
+}) {
+  return prisma.coreAuditLog.create({ data: params });
+}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,0 +1,31 @@
+import { PrismaAdapter } from '@next-auth/prisma-adapter';
+import { compare } from 'bcryptjs';
+import type { NextAuthOptions } from 'next-auth';
+import CredentialsProvider from 'next-auth/providers/credentials';
+import { prisma } from '@/lib/prisma';
+
+export const authOptions: NextAuthOptions = {
+  adapter: PrismaAdapter(prisma),
+  session: { strategy: 'database' },
+  pages: { signIn: '/auth/login' },
+  providers: [
+    CredentialsProvider({
+      name: 'Credentials',
+      credentials: { email: { label: 'Email', type: 'email' }, password: { label: 'Password', type: 'password' } },
+      async authorize(credentials) {
+        if (!credentials?.email || !credentials.password) return null;
+        const user = await prisma.coreUser.findUnique({ where: { email: credentials.email } });
+        if (!user) return null;
+        const valid = await compare(credentials.password, user.passwordHash);
+        if (!valid) return null;
+        return { id: user.id, email: user.email, name: user.name };
+      }
+    })
+  ],
+  callbacks: {
+    async session({ session, user }) {
+      if (session.user) session.user.id = user.id;
+      return session;
+    }
+  }
+};

--- a/lib/events.ts
+++ b/lib/events.ts
@@ -1,0 +1,5 @@
+import { prisma } from '@/lib/prisma';
+
+export async function publishEvent(tenantId: string, type: string, payload: unknown, actor: unknown) {
+  return prisma.coreEvent.create({ data: { tenantId, type, payload: payload as object, actor: actor as object } });
+}

--- a/lib/invitations.ts
+++ b/lib/invitations.ts
@@ -1,0 +1,19 @@
+import crypto from 'crypto';
+import { prisma } from '@/lib/prisma';
+
+export function createInviteToken() {
+  const token = crypto.randomBytes(32).toString('hex');
+  const tokenHash = crypto.createHash('sha256').update(token).digest('hex');
+  return { token, tokenHash };
+}
+
+export function buildInviteMessage(link: string, tenantName: string) {
+  return `You've been invited to join ${tenantName} on AiBizos. Open this secure invite: ${link}`;
+}
+
+export async function expireStaleInvites() {
+  await prisma.coreInvitation.updateMany({
+    where: { status: 'pending', expiresAt: { lt: new Date() } },
+    data: { status: 'expired' }
+  });
+}

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,0 +1,6 @@
+import { PrismaClient } from '@prisma/client';
+
+const globalForPrisma = globalThis as unknown as { prisma: PrismaClient | undefined };
+
+export const prisma = globalForPrisma.prisma ?? new PrismaClient();
+if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma;

--- a/lib/tenant.ts
+++ b/lib/tenant.ts
@@ -1,0 +1,15 @@
+import { prisma } from '@/lib/prisma';
+
+export async function requireTenantContext(userId: string, tenantId: string) {
+  const membership = await prisma.coreMembership.findUnique({
+    where: { tenantId_userId: { tenantId, userId } },
+    include: { roles: { include: { role: { include: { permissions: { include: { permission: true } } } } } } }
+  });
+  if (!membership || membership.status !== 'active') throw new Error('Unauthorized tenant access');
+  const permissions = membership.roles.flatMap((r) => r.role.permissions.map((p) => p.permission.key));
+  return { membership, permissions };
+}
+
+export function requirePermission(granted: string[], needed: string) {
+  if (!granted.includes(needed)) throw new Error(`Missing permission: ${needed}`);
+}

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -1,0 +1,5 @@
+{
+  "nav.dashboard": "لوحة التحكم",
+  "nav.apps": "التطبيقات",
+  "nav.settings": "الإعدادات"
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,0 +1,5 @@
+{
+  "nav.dashboard": "Dashboard",
+  "nav.apps": "Apps",
+  "nav.settings": "Settings"
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,11 @@
+import createMiddleware from 'next-intl/middleware';
+
+export default createMiddleware({
+  locales: ['en', 'ar'],
+  defaultLocale: 'en',
+  localePrefix: 'always'
+});
+
+export const config = {
+  matcher: ['/((?!api|_next|.*\\..*).*)']
+};

--- a/modules/crm/manifest.ts
+++ b/modules/crm/manifest.ts
@@ -1,0 +1,12 @@
+export default {
+  id: 'crm',
+  name: 'CRM',
+  description: 'CRM module',
+  icon: 'Users',
+  routes: ['/modules/crm'],
+  requiredPermissions: ['apps.view.crm'],
+  settingsSections: ['crm.pipeline'],
+  eventsPublished: ['crm.contact.created'],
+  eventsSubscribed: [],
+  aiActions: ['create-contact-draft']
+};

--- a/modules/invoicing/manifest.ts
+++ b/modules/invoicing/manifest.ts
@@ -1,0 +1,12 @@
+export default {
+  id: 'invoicing',
+  name: 'Invoicing',
+  description: 'Draft-first invoicing module',
+  icon: 'Receipt',
+  routes: ['/modules/invoicing'],
+  requiredPermissions: ['apps.view.invoicing'],
+  settingsSections: ['invoice.defaults'],
+  eventsPublished: ['invoice.draft.created'],
+  eventsSubscribed: [],
+  aiActions: ['create-invoice-draft']
+};

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  images: { unoptimized: true }
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "aibizos-core",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "prisma:generate": "prisma generate",
+    "prisma:migrate": "prisma migrate dev",
+    "prisma:seed": "tsx prisma/seed.ts"
+  },
+  "dependencies": {
+    "@hookform/resolvers": "^3.9.0",
+    "@next-auth/prisma-adapter": "^1.0.7",
+    "@prisma/client": "^5.19.1",
+    "@radix-ui/react-select": "^2.1.1",
+    "bcryptjs": "^2.4.3",
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.436.0",
+    "next": "14.2.6",
+    "next-auth": "^4.24.7",
+    "next-intl": "^3.17.3",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
+    "react-hook-form": "^7.53.0",
+    "tailwind-merge": "^2.5.2",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/node": "^22.5.0",
+    "@types/react": "^18.3.5",
+    "@types/react-dom": "^18.3.0",
+    "autoprefixer": "^10.4.20",
+    "eslint": "^8.57.0",
+    "eslint-config-next": "14.2.6",
+    "postcss": "^8.4.41",
+    "prisma": "^5.19.1",
+    "tailwindcss": "^3.4.10",
+    "tsx": "^4.19.1",
+    "typescript": "^5.5.4"
+  },
+  "prisma": {
+    "seed": "tsx prisma/seed.ts"
+  }
+}

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,252 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+enum MembershipStatus {
+  active
+  pending
+}
+
+enum InvitationStatus {
+  pending
+  accepted
+  revoked
+  expired
+}
+
+enum AiRunStatus {
+  planning
+  preview_ready
+  confirmed
+  executed
+  failed
+}
+
+model CoreUser {
+  id           String               @id @default(cuid())
+  email        String               @unique
+  name         String?
+  passwordHash String
+  createdAt    DateTime             @default(now())
+  updatedAt    DateTime             @updatedAt
+  preferences  CoreUserPreference?
+  memberships  CoreMembership[]
+  aiRuns       CoreAiRun[]
+  auditLogs    CoreAuditLog[]
+  accounts     Account[]
+  sessions     Session[]
+}
+
+model CoreUserPreference {
+  id        String   @id @default(cuid())
+  userId    String   @unique
+  locale    String   @default("en")
+  timezone  String   @default("Asia/Riyadh")
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  user      CoreUser @relation(fields: [userId], references: [id])
+}
+
+model CoreTenant {
+  id          String           @id @default(cuid())
+  name        String
+  createdAt   DateTime         @default(now())
+  updatedAt   DateTime         @updatedAt
+  memberships CoreMembership[]
+  roles       CoreRole[]
+  invitations CoreInvitation[]
+  settings    CoreSetting[]
+  apps        CoreTenantApp[]
+  events      CoreEvent[]
+  auditLogs   CoreAuditLog[]
+  aiRuns      CoreAiRun[]
+}
+
+model CoreMembership {
+  id        String           @id @default(cuid())
+  tenantId  String
+  userId    String
+  status    MembershipStatus @default(active)
+  createdAt DateTime         @default(now())
+  tenant    CoreTenant       @relation(fields: [tenantId], references: [id])
+  user      CoreUser         @relation(fields: [userId], references: [id])
+  roles     CoreMembershipRole[]
+  invites   CoreInvitation[] @relation("InviterMembership")
+
+  @@unique([tenantId, userId])
+  @@index([tenantId, id])
+}
+
+model CoreRole {
+  id          String               @id @default(cuid())
+  tenantId    String
+  name        String
+  description String?
+  tenant      CoreTenant           @relation(fields: [tenantId], references: [id])
+  permissions CoreRolePermission[]
+  memberships CoreMembershipRole[]
+
+  @@unique([tenantId, name])
+  @@index([tenantId, id])
+}
+
+model CorePermission {
+  id          String               @id @default(cuid())
+  key         String               @unique
+  description String
+  roles       CoreRolePermission[]
+}
+
+model CoreRolePermission {
+  roleId       String
+  permissionId String
+  role         CoreRole       @relation(fields: [roleId], references: [id])
+  permission   CorePermission @relation(fields: [permissionId], references: [id])
+
+  @@id([roleId, permissionId])
+}
+
+model CoreMembershipRole {
+  membershipId String
+  roleId       String
+  membership   CoreMembership @relation(fields: [membershipId], references: [id])
+  role         CoreRole       @relation(fields: [roleId], references: [id])
+
+  @@id([membershipId, roleId])
+}
+
+model CoreInvitation {
+  id                  String           @id @default(cuid())
+  tenantId            String
+  inviterMembershipId String
+  email               String?
+  phone               String?
+  tokenHash           String           @unique
+  status              InvitationStatus @default(pending)
+  expiresAt           DateTime
+  usedAt              DateTime?
+  createdAt           DateTime         @default(now())
+  tenant              CoreTenant       @relation(fields: [tenantId], references: [id])
+  inviterMembership   CoreMembership   @relation("InviterMembership", fields: [inviterMembershipId], references: [id])
+
+  @@index([tenantId, id])
+  @@index([tenantId, status, expiresAt])
+}
+
+model CoreSetting {
+  id        String   @id @default(cuid())
+  tenantId  String
+  key       String
+  value     Json
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  tenant    CoreTenant @relation(fields: [tenantId], references: [id])
+
+  @@unique([tenantId, key])
+  @@index([tenantId, id])
+}
+
+model CoreAppRegistry {
+  id          String   @id
+  manifest    Json
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+}
+
+model CoreTenantApp {
+  id        String   @id @default(cuid())
+  tenantId  String
+  appId     String
+  installedAt DateTime @default(now())
+  tenant    CoreTenant @relation(fields: [tenantId], references: [id])
+
+  @@unique([tenantId, appId])
+  @@index([tenantId, id])
+}
+
+model CoreEvent {
+  id        String   @id @default(cuid())
+  tenantId  String
+  type      String
+  payload   Json
+  actor     Json
+  createdAt DateTime @default(now())
+  tenant    CoreTenant @relation(fields: [tenantId], references: [id])
+
+  @@index([tenantId, id])
+  @@index([tenantId, createdAt])
+}
+
+model CoreAuditLog {
+  id          String   @id @default(cuid())
+  tenantId    String
+  actorUserId String?
+  action      String
+  entity      String
+  before      Json?
+  after       Json?
+  meta        Json?
+  createdAt   DateTime @default(now())
+  tenant      CoreTenant @relation(fields: [tenantId], references: [id])
+  actorUser   CoreUser? @relation(fields: [actorUserId], references: [id])
+
+  @@index([tenantId, id])
+  @@index([tenantId, createdAt])
+  @@index([tenantId, actorUserId, createdAt])
+}
+
+model CoreAiRun {
+  id          String      @id @default(cuid())
+  tenantId    String
+  actorUserId String
+  prompt      String
+  plan        Json?
+  toolCalls   Json?
+  status      AiRunStatus @default(planning)
+  createdAt   DateTime    @default(now())
+  updatedAt   DateTime    @updatedAt
+  tenant      CoreTenant  @relation(fields: [tenantId], references: [id])
+  actorUser   CoreUser    @relation(fields: [actorUserId], references: [id])
+
+  @@index([tenantId, id])
+  @@index([tenantId, actorUserId, createdAt])
+}
+
+model Account {
+  id                 String  @id @default(cuid())
+  userId             String
+  type               String
+  provider           String
+  providerAccountId  String
+  refresh_token      String?
+  access_token       String?
+  expires_at         Int?
+  token_type         String?
+  scope              String?
+  id_token           String?
+  session_state      String?
+  user               CoreUser @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([provider, providerAccountId])
+}
+
+model Session {
+  id           String   @id @default(cuid())
+  sessionToken String   @unique
+  userId       String
+  expires      DateTime
+  user         CoreUser @relation(fields: [userId], references: [id], onDelete: Cascade)
+}
+
+model VerificationToken {
+  identifier String
+  token      String   @unique
+  expires    DateTime
+
+  @@unique([identifier, token])
+}

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,42 @@
+import { hash } from 'bcryptjs';
+import { prisma } from '../lib/prisma';
+import { builtinApps } from '../lib/apps';
+
+async function main() {
+  const passwordHash = await hash('Password123!', 10);
+  const user = await prisma.coreUser.upsert({
+    where: { email: 'demo@aibizos.com' },
+    update: {},
+    create: { email: 'demo@aibizos.com', name: 'Demo User', passwordHash, preferences: { create: { locale: 'en', timezone: 'Asia/Riyadh' } } }
+  });
+
+  const t1 = await prisma.coreTenant.create({ data: { name: 'AiBizos Labs' } });
+  const t2 = await prisma.coreTenant.create({ data: { name: 'Northwind MENA' } });
+
+  const permissions = [
+    'tenant.manage', 'users.invite', 'roles.manage', 'apps.manage', 'apps.view.crm', 'apps.view.invoicing', 'audit.view', 'events.view', 'ai.use'
+  ];
+
+  for (const key of permissions) {
+    await prisma.corePermission.upsert({ where: { key }, update: {}, create: { key, description: key } });
+  }
+
+  for (const tenant of [t1, t2]) {
+    const membership = await prisma.coreMembership.create({ data: { tenantId: tenant.id, userId: user.id, status: 'active' } });
+    for (const roleName of ['Owner', 'Admin', 'Member', 'Viewer']) {
+      const role = await prisma.coreRole.create({ data: { tenantId: tenant.id, name: roleName } });
+      const rolePermissions = roleName === 'Viewer' ? ['audit.view', 'events.view'] : permissions;
+      for (const key of rolePermissions) {
+        const permission = await prisma.corePermission.findUniqueOrThrow({ where: { key } });
+        await prisma.coreRolePermission.create({ data: { roleId: role.id, permissionId: permission.id } });
+      }
+      if (roleName === 'Owner') await prisma.coreMembershipRole.create({ data: { membershipId: membership.id, roleId: role.id } });
+    }
+  }
+
+  for (const app of builtinApps) {
+    await prisma.coreAppRegistry.upsert({ where: { id: app.id }, update: { manifest: app as unknown as object }, create: { id: app.id, manifest: app as unknown as object } });
+  }
+}
+
+main().finally(async () => prisma.$disconnect());

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,20 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: ['./app/**/*.{ts,tsx}', './components/**/*.{ts,tsx}', './lib/**/*.{ts,tsx}'],
+  darkMode: ['class'],
+  theme: {
+    extend: {
+      colors: {
+        background: '#0F172A',
+        foreground: '#E2E8F0',
+        accent: '#22D3EE',
+        slate: '#334155',
+        muted: '#64748B'
+      }
+    }
+  },
+  plugins: []
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    },
+    "plugins": [{ "name": "next" }]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,0 +1,7 @@
+import 'next-auth';
+
+declare module 'next-auth' {
+  interface Session {
+    user?: { id: string; email?: string | null; name?: string | null };
+  }
+}


### PR DESCRIPTION
### Motivation
- Make English (`en`) the default site locale while keeping Arabic (`ar`) fully supported and rendered RTL when selected. 
- Ensure new default propagates to user preferences and seeded demo data so defaults align with the requested locale behavior.

### Description
- Updated localization middleware by changing `locales` order and `defaultLocale` to `'en'` in `middleware.ts`. 
- Changed Prisma user preference default to `"en"` in `prisma/schema.prisma` and updated the demo user preference in `prisma/seed.ts` to `locale: 'en'`. 
- Switched root HTML baseline to `lang="en" dir="ltr"` in `app/layout.tsx` and made the per-locale layout dynamic by computing `dir` in `app/[locale]/layout.tsx` so `ar` renders as `rtl`. 
- Preserved locale-aware navigation and UI shell wiring (e.g. `components/shell.tsx` uses the `locale` param) so Arabic remains available and functional.

### Testing
- Verified replacements and current values using `rg` to search for `defaultLocale`, `@default("en")`, `locale: 'en'`, and `lang="en"`, which returned the updated files as expected. 
- Inspected the applied edits with `git diff` to confirm the exact changes to `middleware.ts`, `prisma/schema.prisma`, `prisma/seed.ts`, `app/layout.tsx`, and `app/[locale]/layout.tsx`. 
- Printed file contents with `nl` to manually validate the dynamic `dir` logic and schema/seed updates; these checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698874c9d90c8326b39411d7d9499c1e)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ✅ 3 no changes — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2F77cookiez%2FAiBizos%2Fpull%2F1&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->